### PR TITLE
Update talkgroup_ids.json

### DIFF
--- a/talkgroup_ids.json
+++ b/talkgroup_ids.json
@@ -3,17 +3,17 @@
     {
       "tgid": 3120,
       "name": "Kansas Statewide",
-      "id": "3120",
+      "id": "3120"
     },
     {
       "tgid": 31201,
       "name": "BYRG",
-      "id": "31201",
+      "id": "31201"
     },
     {
       "tgid": 310,
       "name": "Kerchunk 310",
-      "id": "310",
+      "id": "310"
     }
   ]
 }


### PR DESCRIPTION
Please update example talkgroup_ids.json to remove coma in each last record. After this HBMonitro read correctly this file without errors. 
Original file produces the error:
Traceback (most recent call last):
  File "web_tables.py", line 627, in <module>
    talkgroup_ids = mk_full_id_dict(PATH, TGID_FILE, 'tgid')
  File "/usr/local/lib/python2.7/dist-packages/dmr_utils/utils.py", line 124, in mk_full_id_dict
    records = jload(_handle)
  File "/usr/lib/python2.7/json/__init__.py", line 291, in load
    **kw)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 380, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Expecting property name: line 7 column 5 (char 101)


Waldek SP2ONG